### PR TITLE
Fix pcoa for distance matrices giving negative but not zero eigenvalues

### DIFF
--- a/R/pcoa.R
+++ b/R/pcoa.R
@@ -83,7 +83,9 @@ bstick.def <- function (n, tot.var = 1, ...)   # 'bstick.default' from vegan
 		eig <- D.eig$values
 		rel.eig <- eig/trace
 		rel.eig.cor <- (eig - min.eig)/(trace - (n-1)*min.eig) # Eq. 9.27 for a single dimension
-		rel.eig.cor = c(rel.eig.cor[1:(zero.eig[1]-1)], rel.eig.cor[(zero.eig[1]+1):n], 0)
+		if (length(zero.eig) > 0) {
+		  rel.eig.cor <- c(rel.eig.cor[-zero.eig[1]], 0)
+		}
 		cum.eig.cor <- cumsum(rel.eig.cor) 
 		k2 <- length(which(eig > epsilon))
 		k3 <- length(which(rel.eig.cor > epsilon))

--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ This is a copy of the APE source code drawing from those hosted at
 <https://github.com/cran/ape> (upstream branch) and
 <https://cran.r-project.org/web/packages/ape> (cran branch).
 The project's official homepage is <http://ape-package.ird.fr>.
+
+## Differences from Latest Version
+
+Relative to the latest official release, this version:
+
+ * Fixes a crash in `pcoa` for distance matrices yielding negative eigenvalues
+   but no zeros

--- a/tests/testthat/test-pcoa.R
+++ b/tests/testthat/test-pcoa.R
@@ -18,3 +18,26 @@ test_that("pcoa works for negative and zero eigenvalues", {
     )
   testthat::expect_equal(res$vectors, vectors_expected)
 })
+
+test_that("pcoa works for negative eigenvalues without zeros", {
+  # An example we happened to come across.
+  # This produces a negative eigenvalue but no zeros.
+  mat <- matrix(c(
+    0,          59633.81,  42459.76,    564168.2,  670052.05,
+    59633.81,   0,         37536.54,    597805.81, 698804.26,
+    42459.76,   37536.54,  0,           572604.99, 677570.94,
+    564168.2,   597805.81, 572604.99,   0,         634495.37,
+    670052.05,  698804.26, 677570.94,   634495.37, 0),
+    nrow = 5)
+  res <- pcoa(mat)
+  vectors_expected <- matrix(c(
+    -199622.580626,  -38512.363296,  28532.5064323,  2233.399746,
+    -233618.667501,  -52454.021499, -17596.4841040,  11076.68935,
+    -208872.298131,  -41919.649398,  -9515.3477495, -13829.76118,
+    199250.430648,  359375.180314,   -929.9073032,    349.89628,
+    442863.115610, -226489.146121,   -490.7672755,    169.77580),
+    nrow = 5, byrow = TRUE,
+    dimnames = list(c(), paste("Axis", 1:4, sep = "."))
+  )
+  expect_equal(res$vectors, vectors_expected)
+})


### PR DESCRIPTION
This modifies the `pcoa` function to check if there are any near-zero eigenvalues before attempting to use them (fixes #1).